### PR TITLE
Make type dirtyFunc -> DirtyFunc (public)

### DIFF
--- a/cache/flusher.go
+++ b/cache/flusher.go
@@ -8,14 +8,14 @@ import(
 	log "github.com/Sirupsen/logrus"
 )
 
-type dirtyFunc func(storage.FileEntry) bool
+type DirtyFunc func(storage.FileEntry) bool
 
 type Flusher struct {
 	store storage.Storage
 	dirty func(storage.FileEntry) bool
 }
 
-func NewFlusher(s storage.Storage, fn dirtyFunc) Flusher {
+func NewFlusher(s storage.Storage, fn DirtyFunc) Flusher {
 	return Flusher{ store: s, dirty: fn }
 }
 


### PR DESCRIPTION
I made dirtyFunc public now so I can do something like the following

https://github.com/donny-dont/drone-s3-cache/pull/2/commits/3e6e205d86bcdb7cd87fbc1c90be795aee5a19a6#diff-70e973989f81df39acd35aa417b206bcR66

This was to allow parameterizing the age of files to cleanup in `drone-s3-cache`.