### PR TITLE
Update logrus path

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,5 +1,5 @@
 [[constraint]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   version = "1.0.5"
 
 [[constraint]]

--- a/archive/tar/tar.go
+++ b/archive/tar/tar.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/drone/drone-cache-lib/archive"
 )
 
@@ -50,7 +50,7 @@ func (a *tarArchive) Pack(srcs []string, w io.Writer) error {
 				if link, err = os.Readlink(path); err != nil {
 					return err
 				}
-				logrus.Debugf("Symbolic link found at %s to %s", path, link)
+				log.Debugf("Symbolic link found at %s to %s", path, link)
 
 				// Rewrite header for SymLink
 				header, err = tar.FileInfoHeader(fi, link)
@@ -66,11 +66,11 @@ func (a *tarArchive) Pack(srcs []string, w io.Writer) error {
 			}
 
 			if !fi.Mode().IsRegular() {
-				logrus.Debugf("Directory found at %s", path)
+				log.Debugf("Directory found at %s", path)
 				return nil
 			}
 
-			logrus.Debugf("File found at %s", path)
+			log.Debugf("File found at %s", path)
 
 			file, err := os.Open(path)
 			if err != nil {
@@ -123,7 +123,7 @@ func (a *tarArchive) Unpack(dst string, r io.Reader) error {
 
 		// if its a symlink and it doesn't exist create it
 		case tar.TypeSymlink:
-			logrus.Debugf("Symlink found at %s", target)
+			log.Debugf("Symlink found at %s", target)
 
 			// Check if something already exists
 			_, err := os.Stat(target)
@@ -132,17 +132,17 @@ func (a *tarArchive) Unpack(dst string, r io.Reader) error {
 			}
 
 			// Create the link
-			logrus.Debugf("Creating link %s to %s", target, header.Linkname)
+			log.Debugf("Creating link %s to %s", target, header.Linkname)
 			err = os.Symlink(header.Linkname, target)
 
 			if err != nil {
-				logrus.Infof("Failed creating link %s to %s", target, header.Linkname)
+				log.Infof("Failed creating link %s to %s", target, header.Linkname)
 				return err
 			}
 
 		// if its a dir and it doesn't exist create it
 		case tar.TypeDir:
-			logrus.Debugf("Directory found at %s", target)
+			log.Debugf("Directory found at %s", target)
 			if _, err := os.Stat(target); err != nil {
 				if err := os.MkdirAll(target, 0755); err != nil {
 					return err
@@ -151,7 +151,7 @@ func (a *tarArchive) Unpack(dst string, r io.Reader) error {
 
 		// if it's a file create it
 		case tar.TypeReg:
-			logrus.Debugf("File found at %s", target)
+			log.Debugf("File found at %s", target)
 			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
 				return err

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"io"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/drone/drone-cache-lib/archive"
 	"github.com/drone/drone-cache-lib/archive/tar"
 	"github.com/drone/drone-cache-lib/storage"
@@ -36,14 +36,14 @@ func (c Cache) Restore(src string, fallback string) error {
 	err := restoreCache(src, c.s, c.a)
 
 	if err != nil && fallback != "" && fallback != src {
-		logrus.Warnf("Failed to retrieve %s, trying %s", src, fallback)
+		log.Warnf("Failed to retrieve %s, trying %s", src, fallback)
 		err = restoreCache(fallback, c.s, c.a)
 	}
 
 	// Cache plugin should print an error but it should not return it
 	// this is so the build continues even if the cache cant be restored
 	if err != nil {
-		logrus.Warnf("Cache could not be restored %s", err)
+		log.Warnf("Cache could not be restored %s", err)
 	}
 
 	return nil
@@ -72,7 +72,7 @@ func restoreCache(src string, s storage.Storage, a archive.Archive) error {
 }
 
 func rebuildCache(srcs []string, dst string, s storage.Storage, a archive.Archive) error {
-	logrus.Infof("Rebuilding cache at %s to %s", srcs, dst)
+	log.Infof("Rebuilding cache at %s to %s", srcs, dst)
 
 	reader, writer := io.Pipe()
 	defer reader.Close()

--- a/cache/flusher.go
+++ b/cache/flusher.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/drone/drone-cache-lib/storage"
 )
 
@@ -28,7 +28,7 @@ func NewDefaultFlusher(s storage.Storage) Flusher {
 
 // Flush cleans the cache if it's expired.
 func (f *Flusher) Flush(src string) error {
-	logrus.Infof("Cleaning files from %s", src)
+	log.Infof("Cleaning files from %s", src)
 
 	files, err := f.store.List(src)
 	if err != nil {

--- a/storage/dummy/dummy.go
+++ b/storage/dummy/dummy.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/drone/drone-cache-lib/storage"
 )
 
@@ -37,22 +37,22 @@ func (s *dummyStorage) Get(p string, dst io.Writer) error {
 }
 
 func (s *dummyStorage) Put(p string, src io.Reader) error {
-	logrus.Infof("Reading for %s", p)
+	log.Infof("Reading for %s", p)
 
 	_, err := ioutil.ReadAll(src)
 
 	if err != nil {
-		logrus.Errorf("Failed to read for %s", p)
+		log.Errorf("Failed to read for %s", p)
 		return err
 	}
 
-	logrus.Infof("Finished reading for %s", p)
+	log.Infof("Finished reading for %s", p)
 
 	return nil
 }
 
 func (s *dummyStorage) List(p string) ([]storage.FileEntry, error) {
-	logrus.Infof("Retrieving list of files from %s", p)
+	log.Infof("Retrieving list of files from %s", p)
 
 	var files []storage.FileEntry
 	fwErr := filepath.Walk(p, func(path string, fi os.FileInfo, err error) error {
@@ -77,7 +77,7 @@ func (s *dummyStorage) List(p string) ([]storage.FileEntry, error) {
 }
 
 func (s *dummyStorage) Delete(p string) error {
-	logrus.Infof("Deleteing %s", p)
+	log.Infof("Deleteing %s", p)
 
 	return os.Remove(p)
 }


### PR DESCRIPTION
When updating the deps in drone-s3-cache I stumbled upon this issue with dep https://github.com/golang/dep/issues/1010

Minio-go is using the updated lowercase siruspen while drone-cache-lib is using the uppercase.