### PR TITLE
Set mtime when restoring from tar

### DIFF
--- a/archive/tar/tar.go
+++ b/archive/tar/tar.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/drone/drone-cache-lib/archive"
@@ -162,6 +163,12 @@ func (a *tarArchive) Unpack(dst string, r io.Reader) error {
 
 			// Explicitly close otherwise too many files remain open
 			f.Close()
+
+			if err != nil {
+				return err
+			}
+
+			err = os.Chtimes(target, time.Now(), header.ModTime)
 
 			if err != nil {
 				return err


### PR DESCRIPTION
I use the [s3 cache plugin](https://github.com/drone-plugins/drone-s3-cache), which internally uses this library. When restoring the cache, the modification date of all files is set to the current time.

My pipeline uses the modification date to check if the source file is newer than the built file (which is restored from the cache) and only rebuilds it in that case.

This PR adds the modification date to each file after unpacking to enable such pipelines to work.

I am not an experienced Go programmer, so please tell me if there is a better way of doing this.