### PR TITLE
Remove file path trimming in tar compress

### DIFF
--- a/archive/tar/tar.go
+++ b/archive/tar/tar.go
@@ -9,11 +9,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/drone/drone-cache-lib/archive"
+	log "github.com/sirupsen/logrus"
 )
 
 type tarArchive struct{}
@@ -60,7 +59,7 @@ func (a *tarArchive) Pack(srcs []string, w io.Writer) error {
 				}
 			}
 
-			header.Name = strings.TrimPrefix(filepath.ToSlash(path), "/")
+			header.Name = filepath.ToSlash(path)
 
 			if err = tw.WriteHeader(header); err != nil {
 				return err


### PR DESCRIPTION
I'm using s3-cache plugin and I need to cache an absolute path (/var/lib/docker), so for doing that compression lib must accept and work with absolute paths. There is a line that trim the first "/", and that is the reason that the plugin can't work with absolute path.

The solution is avoid trim the path.